### PR TITLE
Defined custom WiFi hostname based on config value

### DIFF
--- a/slack-door-controller/ControllerConfigs_Example.h
+++ b/slack-door-controller/ControllerConfigs_Example.h
@@ -11,6 +11,9 @@
 // The channel identifier (i.e. GP6F6369C)
 #define SLACK_CHANNEL_ID ""
 
+// The name that will appear in the network (router) to ease the identification (Rules: https://www.ietf.org/rfc/rfc1178.txt)
+#define NETWORK_HOSTNAME ""
+
 // The name that will be used in every message sent by the controller
 #define CONTROLLER_NAME  ""
 

--- a/slack-door-controller/slack-door-controller.ino
+++ b/slack-door-controller/slack-door-controller.ino
@@ -380,7 +380,13 @@ void setup() {
   delay(500);
   Serial.println();
 
+  // Set WiFi mode to Station in order to connect to a network
   WiFi.mode(WIFI_STA);
+
+  // Set the visible network name (instead of the default ESP_XXXX)
+  WiFi.hostname(NETWORK_HOSTNAME);
+
+  // Start the WiFi connection
   WiFiMulti.addAP(WIFI_SSID, WIFI_PASSWORD);
   while (WiFiMulti.run() != WL_CONNECTED) {
     delay(WIFI_CONNECTION_DURATION);


### PR DESCRIPTION
To ease the identification of a controller in a network mapping, a new NETWORK_HOSTNAME value has been added to the ControllerConfigs file where the name can be written. However, it should follow the rules from [RFC1178](https://www.ietf.org/rfc/rfc1178.txt).